### PR TITLE
Update GraalVM workflow with new command option

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -32,7 +32,7 @@ jobs:
                 version: latest
 
             - name: Run Ballerina tests using the native executable
-              run: bal test --native ./sns
+              run: bal test --graalvm ./sns
               env:
                 ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
                 SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This PR will rename the command option in the graalVM workflow from --native to --graalvm. Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/531