### PR TITLE
Revert "Temporary disable tests on the release build"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
       package-org: ballerinax
       additional-build-flags: "-x :aws.sns-examples:build"
       additional-publish-flags: "-x :aws.sns-examples:build"
-      additional-release-flags: "-x :aws.sns-examples:build -x test"
+      additional-release-flags: "-x :aws.sns-examples:build"


### PR DESCRIPTION
Reverts ballerina-platform/module-ballerinax-aws.sns#99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request reverts a previous change that had disabled test execution during release builds. The modification re-enables tests by removing the `-x test` exclusion flag from the release workflow's `additional-release-flags` input parameter. This ensures that tests are executed as part of the release build process, improving the reliability of the release pipeline.

## Changed Files

- `.github/workflows/release.yml`: Updated the `additional-release-flags` input to remove the test exclusion flag, allowing tests to run during the release step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->